### PR TITLE
Add bcrypt support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,17 @@
 FROM python:3-alpine
 MAINTAINER Thomas Queste <tom@tomsquest.com>
 
-RUN apk add --update tini su-exec
-
-RUN pip install radicale
+RUN apk add --no-cache \
+    tini \
+    su-exec \
+    gcc \
+    libffi-dev \
+    musl-dev \
+    && pip install radicale passlib[bcrypt] \
+    && apk del \
+    gcc \
+    libffi-dev \
+    musl-dev
 
 # User with no home, no password
 RUN adduser -s /bin/false -D -H radicale


### PR DESCRIPTION
Hi @tomsquest,

thanks for your awesome docker image.

I'm using it with the new htpasswd authentication introduced in 2.0 in bcrypt mode.
Radicale requires the passlib for bcrypt to allow bcrypt htpasswd files.

The changes in this pull request allow users to use htpasswd-files with secure bcrypt.

Best,
Enno