### PR TITLE
Set the version of radicale (to help with tagging images)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:3-alpine
 MAINTAINER Thomas Queste <tom@tomsquest.com>
 
+ENV VERSION=2.1.8
+
 RUN apk add --no-cache --virtual=build-dependencies \
         gcc \
         libffi-dev \
@@ -9,12 +11,12 @@ RUN apk add --no-cache --virtual=build-dependencies \
         git \
         su-exec \
         tini \
-    && pip install radicale passlib[bcrypt] \
+    && pip install radicale==$VERSION passlib[bcrypt] \
     && apk del --purge build-dependencies
 
 
 # User with no home, no password
-RUN adduser -s /bin/false -D -H radicale
+RUN adduser -s /bin/false -D -H -u 799 radicale
 
 COPY config /radicale
 RUN mkdir -p /radicale/data && chown radicale /radicale/data


### PR DESCRIPTION
Specify a (system) user id for the radicale user. Means you can create a host user with matching id so that file permissions are preserved.