### PR TITLE
Pre-define a user id

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache --virtual=build-dependencies \
 
 
 # User with no home, no password
-RUN adduser -s /bin/false -D -H radicale
+RUN adduser -s /bin/false -D -H -u 2999 radicale
 
 COPY config /radicale
 RUN mkdir -p /radicale/data && chown radicale /radicale/data


### PR DESCRIPTION
Configure the radicale user to a set user id (2999) rather than letting it default to 1000.

This gives hosts the option of creating a user (with id 2999) on the host, so that file/folder ownership can match up between host and container. 