### PR TITLE
Explicitly set the version of Radicale

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:3-alpine
 MAINTAINER Thomas Queste <tom@tomsquest.com>
 
+ENV VERSION=2.1.8
+
 RUN apk add --no-cache --virtual=build-dependencies \
         gcc \
         libffi-dev \
@@ -9,7 +11,7 @@ RUN apk add --no-cache --virtual=build-dependencies \
         git \
         su-exec \
         tini \
-    && pip install radicale passlib[bcrypt] \
+    && pip install radicale==$VERSION passlib[bcrypt] \
     && apk del --purge build-dependencies
 
 


### PR DESCRIPTION
Explicity set the version of radicale so that changes to the version (and hence commits), trigger dockerhub builds. 

Also for building/testing locally, changing the version breaks the docker cache, forcing a full rebuild. 