### PR TITLE
Can override the default user/group ID when building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,11 @@ RUN apk add --no-cache --virtual=build-dependencies \
     && pip install radicale passlib[bcrypt] \
     && apk del --purge build-dependencies
 
-
-# User with no home, no password
-RUN adduser -s /bin/false -D -H radicale
+# Create user and its group, with no home and no password
+ARG UID=1000
+ARG GID=1000
+RUN addgroup -g $GID radicale
+RUN adduser -D -s /bin/false -H -u $UID -G radicale radicale
 
 RUN mkdir -p /config /data && chown -R radicale /config /data
 COPY config /config

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN apk add --no-cache --virtual=build-dependencies \
     && apk del --purge build-dependencies
 
 # Create user and its group, with no home and no password
-ARG UID=1000
-ARG GID=1000
+ARG UID=2999
+ARG GID=2999
 RUN addgroup -g $GID radicale
 RUN adduser -D -s /bin/false -H -u $UID -G radicale radicale
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ docker run -d --name radicale \
     tomsquest/docker-radicale
 ```
 
+## User/Group ID
+
+If you want another user to run the docker container and so "share" files with fixed permission between the host and the container, two options:
+1. Create a user on your host with ID `2999` (hardcoded in the built image): `useradd --uid 2999 radicale`
+1. Or build the image yourself and specify the user ID you want: `docker build -t radicale --build-arg=UID=5000 --build-arg=GID=5001 .` (see the [Building](#Building) section below)
+
+The first option is far easier. [Robert Beal](https://github.com/tomsquest/docker-radicale/pull/9#issuecomment-337834890) said it simply:
+> The main problem with **building** is that you either have to do so on your own environment (and push the image to your own registry so that prod can access it) or you build on your production environment (which isn't ideal either). It means dealing with source code and git pulls etc... and you have to manage updating it all so more responsibility is put on the consumer.
+
 ## Building
 
 Build the image:
@@ -68,6 +77,20 @@ Then run the container:
 
 ```
 docker run -d --name radicale -p 5232:5232 radicale
+```
+
+When building, you can specify the user ID and group ID of the `radicale` user created in the container. 
+This is useful because files created by the `radicale` user can then match one of your user on your host.  
+This is an optional feature of this image.  
+By default, the `radicale` user has a user ID of `2999` and a group ID of `2999`.
+By the way, we could have "change" the IDs when the container is run, but this would prevent us from running the container readonly (with the `--read-only` flag).
+
+```
+# Let's create a user/group 5000/5001 on your host
+sudo addgroup --gid 5001 radicale
+sudo adduser --gid 5001 --uid 5000 --shell /bin/false --disabled-password --no-create-home radicale
+# Then build the image with these IDs
+docker build -t radicale --build-arg=UID=5000 --build-arg=GID=5001 .
 ```
 
 ## Radicale configuration


### PR DESCRIPTION
Supersedes #9 

We want non-conflictual user id between host and container.

Done:
* hardcode the user/group ID: Chosen value: 2999
* Let's the hoster, rebuild the image with its own UID/GID
