### PR TITLE
Get back to the default configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_install:
 script:
   - docker ps | grep -q radicale
   - sleep 10
-  - curl -sSL http://127.0.0.1:5232 | grep -q "Login"
+  - curl --fail http://localhost:5232 || exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_install:
 script:
   - docker ps | grep -q radicale
   - sleep 10
-  - curl -sSL http://127.0.0.1:5232 | grep -q "Radicale works"
+  - curl -sSL http://127.0.0.1:5232 | grep -q "Login"

--- a/config/config
+++ b/config/config
@@ -92,7 +92,6 @@ hosts = 0.0.0.0:5232
 # Rights backend
 # Value: none | authenticated | owner_only | owner_write | from_file
 #type = owner_only
-type = none
 
 # File for rights management from_file
 #file = /etc/radicale/rights
@@ -135,7 +134,7 @@ filesystem_folder = /data/collections
 # Web interface backend
 # Value: none | internal
 #type = internal
-type = none
+
 
 [logging]
 


### PR DESCRIPTION
This PR restores the default configuration settings to a more pristine version (ie. Radicale official config).

Our config file still has:
* `hosts`: must be _opened_ for the container to accept connections from the host
* `filesystem_folder` to point to the `/data` dir/volume

Previously I had disabled the default UI of Radicale v2 in the embedded config file.
The rights were also force to "none" (and its seems to already be the default).
