### PR TITLE
Use usermod/groupmod to modify the user/group at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.6.3-alpine3.6
 MAINTAINER Thomas Queste <tom@tomsquest.com>
 
 ENV VERSION=2.1.8
@@ -9,6 +9,7 @@ RUN apk add --no-cache --virtual=build-dependencies \
         musl-dev \
     && apk add --no-cache \
         git \
+        shadow \
         su-exec \
         tini \
     && pip install radicale==$VERSION passlib[bcrypt] \

--- a/README.md
+++ b/README.md
@@ -57,12 +57,25 @@ docker run -d --name radicale \
      -v ~/radicale/config:/config:ro \
     tomsquest/docker-radicale
 ```
+Run latest, using custom UID and GID (`--read-only` is not possible with this method):
+
+```
+docker run -d --name radicale \
+    -p 5232:5232 \
+     --read-only \
+     -e UID=1111 \
+     -e GID=2222 \
+     -v ~/radicale/data:/data \
+     -v ~/radicale/config:/config:ro \
+    tomsquest/docker-radicale
+```
 
 ## User/Group ID
 
 If you want another user to run the docker container and so "share" files with fixed permission between the host and the container, two options:
 1. Create a user on your host with ID `2999` (hardcoded in the built image): `useradd --uid 2999 radicale`
-1. Or build the image yourself and specify the user ID you want: `docker build -t radicale --build-arg=UID=5000 --build-arg=GID=5001 .` (see the [Building](#Building) section below)
+2. Specify `-e UID=123` and `-e GID=456` for user and group Id's. `--read-only` is not possible with this method as it modifes the filesystem at runtime.
+3. Or build the image yourself and specify the user ID you want: `docker build -t radicale --build-arg=UID=5000 --build-arg=GID=5001 .` (see the [Building](#Building) section below)
 
 The first option is far easier. [Robert Beal](https://github.com/tomsquest/docker-radicale/pull/9#issuecomment-337834890) said it simply:
 > The main problem with **building** is that you either have to do so on your own environment (and push the image to your own registry so that prod can access it) or you build on your production environment (which isn't ideal either). It means dealing with source code and git pulls etc... and you have to manage updating it all so more responsibility is put on the consumer.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ docker run -d --name radicale \
 
 If you want another user to run the docker container and so "share" files with fixed permission between the host and the container, two options:
 1. Create a user on your host with ID `2999` (hardcoded in the built image): `useradd --uid 2999 radicale`
-2. Specify `-e UID=123` and `-e GID=456` for user and group Id's. `--read-only` is not possible with this method as it modifes the filesystem at runtime.
+2. Specify `-e UID=123` and `-e GID=456` for user and group Id's. `--read-only` is not possible with this method as it modifies the filesystem at runtime.
 3. Or build the image yourself and specify the user ID you want: `docker build -t radicale --build-arg=UID=5000 --build-arg=GID=5001 .` (see the [Building](#Building) section below)
 
 The first option is far easier. [Robert Beal](https://github.com/tomsquest/docker-radicale/pull/9#issuecomment-337834890) said it simply:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,14 @@
 #!/bin/sh
 set -e
 
+if [[ -n "$GID" ]]; then
+    groupmod -o -g $GID radicale
+fi
+
+if [[ -n "$UID" ]]; then
+    usermod -o -u $UID radicale
+fi
+
 # Re-set permission to the `radicale` user if current user is root
 # This avoids permission denied if the data volume is mounted by root
 if [ "$1" = 'radicale' -a "$(id -u)" = '0' ]; then


### PR DESCRIPTION
- Update to a newer and more specific version of python alpine (so the shadow package is available)
- Update the readme instructions

This gives people using the container another option for how they want to run it :)