### PR TITLE
Remove tini in favor of `--init`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN apk add --no-cache --virtual=build-dependencies \
         git \
         shadow \
         su-exec \
-        tini \
     && pip install radicale==$VERSION passlib[bcrypt] \
     && pip install --upgrade git+https://github.com/Unrud/RadicaleInfCloud \
     && apk del --purge build-dependencies \
@@ -29,7 +28,6 @@ HEALTHCHECK --interval=30s --retries=3 CMD curl --fail http://localhost:5232 || 
 VOLUME /config /data
 EXPOSE 5232
 
-# Tini starts our entrypoint which then starts Radicale
 COPY docker-entrypoint.sh /usr/local/bin
-ENTRYPOINT ["/sbin/tini", "--", "docker-entrypoint.sh"]
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["radicale", "--config", "/config/config"]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ This container is for Radicale version 2.x, as of 2017.07.
 
 Special points:
 * Security: run as a normal user (not root!) with the help of [su-exec](https://github.com/ncopa/su-exec) (ie. [gosu](https://github.com/tianon/gosu) in C)
-* Process management: use [Tini](https://github.com/krallin/tini) to handle init (pid 0)
 * Safe volume permissions: `/config` and `/data` can be mounted by your user or root and they will still be readable by the `radicale` user inside the container
 * Small size: run on [python:3-alpine](https://hub.docker.com/_/python/)
 * Git and Bcrypt included for [versioning](http://radicale.org/versioning/) and [authentication](http://radicale.org/setup/#authentication) and [InfCloud](https://www.inf-it.com/open-source/clients/infcloud/) if you need an UI
@@ -43,6 +42,7 @@ docker run -d --name radicale \
 docker run -d --name radicale \
     -p 127.0.0.1:5232:5232 \
     --read-only \
+    --init \
     --pids-limit 50 \
     --security-opt="no-new-privileges:true" \
     --health-cmd="curl --fail http://localhost:5232 || exit 1" \


### PR DESCRIPTION
This PR removes Tini and instructs to use the `--init` flag when running the container.

Tini is no more needed to handle processes as it is build in docker since version 1.13. From Tini repo:

> If you are using Docker 1.13 or greater, Tini is included in Docker itself. This includes all versions of Docker CE. To enable Tini, just pass the --init flag to docker run. 
> Source: https://github.com/krallin/tini#using-tini

@robertbeal what do you think?