### PR TITLE
Multi-arch builds of radicale!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Dockerfile.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,30 @@
-services:
-  - docker
+services: docker
+language: bash
 
-before_install:
-  - docker build -t radicale .
-  - docker run -d --name radicale -p 127.0.0.1:5232:5232 radicale
+env:
+  global:
+    - VERSION=2.1.9
+  matrix:
+    - ARCH=i386
+    - ARCH=amd64
+    - ARCH=arm
+    - ARCH=aarch64
 
-script:
-  - docker ps | grep -q radicale
+before_script:
+  - ./build.sh $ARCH
+  - docker run --rm --privileged multiarch/qemu-user-static:register --reset
+
+script:  
+  - docker build -t tomsquest/docker-radicale:$ARCH -t tomsquest/docker-radicale:$ARCH.$VERSION --build-arg=VERSION=$VERSION --file Dockerfile.$ARCH .
+  - docker run -d --name=radicale-$ARCH --health-cmd="curl --fail http://localhost:5232 || exit 1" --health-interval=5s --health-retries=3 tomsquest/docker-radicale:$ARCH
   - sleep 10
-  - curl --fail http://localhost:5232 || exit 1
+  - if [[ -z 'docker ps --filter="name=radicale-$ARCH" --filter="health=healthy" -q' ]]; then exit 1; fi
+
+deploy:
+  provider: script
+  script:
+    echo "$DOCKER_PWD" | docker login -u "$DOCKER_USER" --password-stdin &&
+    docker push tomsquest/docker-radicale:$ARCH &&
+    docker push tomsquest/docker-radicale:$ARCH.$VERSION;
+  on:
+    branch: master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.6.4-alpine3.7
-MAINTAINER Thomas Queste <tom@tomsquest.com>
+FROM alpine:3.7
+LABEL maintainer="tom@tomsquest.com"
 
-ENV VERSION=2.1.9
+ARG VERSION=2.1.9
 ARG UID=2999
 ARG GID=2999
 
@@ -9,13 +9,15 @@ RUN apk add --no-cache --virtual=build-dependencies \
         gcc \
         libffi-dev \
         musl-dev \
+        python3-dev \
     && apk add --no-cache \
         curl \
         git \
+        python3 \
         shadow \
         su-exec \
-    && pip install radicale==$VERSION passlib[bcrypt] \
-    && pip install --upgrade git+https://github.com/Unrud/RadicaleInfCloud \
+    && python3 -m pip install radicale==$VERSION passlib[bcrypt] \
+    && python3 -m pip install --upgrade git+https://github.com/Unrud/RadicaleInfCloud \
     && apk del --purge build-dependencies \
     && addgroup -g $GID radicale \
     && adduser -D -s /bin/false -H -u $UID -G radicale radicale \

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+arch=($1)
+
+case ${arch} in
+    i386 ) base_image="resin/i386-alpine" ;;
+    amd64 ) base_image="alpine:3.7" ;;
+    arm ) base_image="resin/rpi-alpine" ;;
+    aarch64 ) base_image="resin/aarch64-alpine" ;;
+esac
+cp Dockerfile Dockerfile.${arch}
+sed -i "s@alpine:\([0-9]\+\).\([0-9]\+\)@$base_image@g" Dockerfile.${arch}

--- a/build.sh
+++ b/build.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
-arch=($1)
+set -euo pipefail
 
-case ${arch} in
+arch="$1"
+
+case "$arch" in
     i386 ) base_image="resin/i386-alpine" ;;
     amd64 ) base_image="alpine:3.7" ;;
     arm ) base_image="resin/rpi-alpine" ;;
     aarch64 ) base_image="resin/aarch64-alpine" ;;
 esac
-cp Dockerfile Dockerfile.${arch}
-sed -i "s@alpine:\([0-9]\+\).\([0-9]\+\)@$base_image@g" Dockerfile.${arch}
+
+sed "s@alpine:\\([0-9]\\+\\).\\([0-9]\\+\\)@$base_image@g" Dockerfile > "Dockerfile.$arch"


### PR DESCRIPTION
This will build radicale in (currently) 4 different architectures using Travis.

- build.sh generates a Dockerfile for each "arch" simply using `sed` to change the base image at the top of the file.
- As a base image (for non amd64 builds) I've used resin's alpine images which have qemu installed
- This has meant installing `python3` and `python3-dev` as part of the build. This actually results in a smaller image (circa 40mb, as the `python3-dev` packages are removed once it is built which they weren't on the `python:3.6.4-alpine3.7` base image)
- You'll need to go into the Settings on your Travis build for radicale, and add two ENV variables, `DOCKER_USER` and `DOCKER_PWD` to allow Travis to push built images to your dockerhub account.
- Variables are now set and controlled in `.travis.yml`, ie that's where you would upgrade the `VERSION`
- I've cleaned up `MAINTAINER` in the Dockerfile as this is a deprecated tag, and replaced it with `LABEL`