### PR TITLE
Release on tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,13 @@ before_script:
 script:
   - pipenv check
   - pipenv run pytest -v
-  - docker build -t tomsquest/docker-radicale:$ARCH -t tomsquest/docker-radicale:$ARCH.$VERSION --build-arg=VERSION=$VERSION --file Dockerfile.$ARCH .
 
 deploy:
   provider: script
   script:
     echo "$DOCKER_PWD" | docker login -u "$DOCKER_USER" --password-stdin &&
+    docker build -t tomsquest/docker-radicale:$ARCH -t tomsquest/docker-radicale:$ARCH.$TRAVIS_TAG --build-arg=VERSION=$VERSION --file Dockerfile.$ARCH . &&
     docker push tomsquest/docker-radicale:$ARCH &&
-    docker push tomsquest/docker-radicale:$ARCH.$VERSION;
+    docker push tomsquest/docker-radicale:$ARCH.$TRAVIS_TAG;
   on:
-    branch: master
+    tags: true


### PR DESCRIPTION
Currently:
- on master change, new images are pushed as docker-radical:$ARCH and docker-radicale:$ARCH-$VERSION

Consequences:
- on master change, published images gets overwritten
- release version (eg. 2.1.10.0) are not released as multi-arch images

This PR does
- only push new images on tag (eg. new tag 2.1.10.0 pushed gives the multi-arch images being built and pushed)

Consequences:
- no images get pushed with version *exactly* matching the version of radicale (we have 2.1.10*.0*, radicale have only 2.1.10 (the last digit in our version is an increment of the Docker image, no Radicale itself)

close #30 