### PR TITLE
Set only version in the Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ python:
   - '3.6'
 
 env:
-  global:
-    - VERSION=2.1.10
   matrix:
     - ARCH=i386
     - ARCH=amd64
@@ -28,7 +26,7 @@ deploy:
   provider: script
   script:
     echo "$DOCKER_PWD" | docker login -u "$DOCKER_USER" --password-stdin &&
-    docker build -t tomsquest/docker-radicale:$ARCH -t tomsquest/docker-radicale:$ARCH.$TRAVIS_TAG --build-arg=VERSION=$VERSION --file Dockerfile.$ARCH . &&
+    docker build -t tomsquest/docker-radicale:$ARCH -t tomsquest/docker-radicale:$ARCH.$TRAVIS_TAG --file Dockerfile.$ARCH . &&
     docker push tomsquest/docker-radicale:$ARCH &&
     docker push tomsquest/docker-radicale:$ARCH.$TRAVIS_TAG;
   skip_cleanup: true


### PR DESCRIPTION
This PR fixes the duplicate version in travis.yml and the Dockerfile.
As we do not release a tag matching the exact version of Radicale, the version in travis.yml is superfluous (the Git tag is used to tag the images).