### PR TITLE
feat: make config only readable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ RUN apk add --no-cache --virtual=build-dependencies \
     && addgroup -g $GID radicale \
     && adduser -D -s /bin/false -H -u $UID -G radicale radicale \
     && mkdir -p /config /data \
-    && chmod -R 700 /config /data \
-    && chown -R radicale /config /data
+    && chmod -R 770 /data \
+    && chown -R radicale:radicale /data
 
 COPY config /config
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+
 set -e
 
 if [[ -n "$GID" ]]; then
@@ -12,7 +13,7 @@ fi
 # Re-set permission to the `radicale` user if current user is root
 # This avoids permission denied if the data volume is mounted by root
 if [ "$1" = 'radicale' -a "$(id -u)" = '0' ]; then
-    chown -R radicale /data
+    chown -R radicale:radicale /data
     exec su-exec radicale "$@"
 fi
 

--- a/test_image.py
+++ b/test_image.py
@@ -34,14 +34,14 @@ def test_user(host):
     assert host.user(user).shell == '/bin/false'
     assert 'radicale L ' in host.check_output('passwd --status radicale')
 
-def test_config_folder(host):
-    folder = '/config'
-    assert host.file(folder).exists
-    assert host.file(folder).user == 'radicale'
-    assert oct(host.file(folder).mode) == '0o700'
+def test_config_readonly(host):
+    config_file = '/config/config'
+    assert host.file(config_file).user == 'root'
+    assert host.file(config_file).group == 'root'
+    assert host.file(config_file).mode == 0o664
 
 def test_data_folder_writable(host):
     folder = '/data'
-    assert host.file(folder).exists
     assert host.file(folder).user == 'radicale'
-    assert oct(host.file(folder).mode) == '0o700'
+    assert host.file(folder).group == 'radicale'
+    assert host.file(folder).mode == 0o770


### PR DESCRIPTION
Make `/config` dir and `/config/config` file reaonly

- `root` owns `/config` and `/config/config`
- default `root` permissions are 664, ie. radicale can read the config file

Also fix permissions not being set for group `radicale`.

Close #33