### PR TITLE
fix: multi-arch fails due to resin images deprecated on docker hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ python:
 
 env:
   matrix:
-    - ARCH=i386
     - ARCH=amd64
+    - ARCH=i386
     - ARCH=arm
     - ARCH=aarch64
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9.4
+FROM alpine:3.9
 
 ARG COMMIT_ID
 ARG VERSION=2.1.11

--- a/build.sh
+++ b/build.sh
@@ -5,10 +5,10 @@ set -euo pipefail
 arch="$1"
 
 case "$arch" in
-    i386 ) base_image="resin/i386-alpine" ;;
-    amd64 ) base_image="alpine:3.8" ;;
-    arm ) base_image="resin/rpi-alpine" ;;
-    aarch64 ) base_image="resin/aarch64-alpine" ;;
+    amd64   ) base_image="balenalib/amd64-alpine:3.9" ;;
+    i386    ) base_image="balenalib/i386-alpine:3.9" ;;
+    arm     ) base_image="balenalib/armv7hf-alpine:3.9" ;;
+    aarch64 ) base_image="balenalib/aarch64-alpine:3.9" ;;
 esac
 
-sed "s@alpine:\\([0-9]\\+\\).\\([0-9]\\+\\)@$base_image@g" Dockerfile > "Dockerfile.$arch"
+sed "1cFROM $base_image" Dockerfile > "Dockerfile.$arch"


### PR DESCRIPTION
Remove deprecated resin/ images and use balenalib/ in place.

Also, forced 3.9 of alpine for all archs.

@robertbeal can you have a look at this?