### PR TITLE
added wget (as alpine/busybox default wget is not linked against ssl)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apk add --no-cache --virtual=build-dependencies \
         musl-dev \
         python3-dev \
     && apk add --no-cache \
+        wget \
         curl \
         git \
         python3 \


### PR DESCRIPTION
Hi,

running your docker for some time now. I have a redicale hook which is actually triggering phonebook sync of contacts in my home network. Since I updated that service to run on https the built in version of busybox/alpine wget is no longer working on the hook (because busybox not having linked its wget against ssl). A simple `apk add wget` would solve my problem. I've added it to the docker file. Would be great if you could merge it. 😃 

Cheers,
m.