### PR TITLE
Update Baseimage Alpine 3.9 -> 3.10 and add tzdata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.10
 
 ARG COMMIT_ID
 ARG VERSION=2.1.11
@@ -26,6 +26,7 @@ RUN apk add --no-cache --virtual=build-dependencies \
         python3 \
         shadow \
         su-exec \
+        tzdata \
     && python3 -m pip install --upgrade pip \
     && python3 -m pip install radicale==$VERSION passlib[bcrypt] \
     && python3 -m pip install --upgrade git+https://github.com/Unrud/RadicaleInfCloud \


### PR DESCRIPTION
I added tzdata to set the correct local time zone. 
To set the time zone the TZ variable must be set in the file docker-compose.yml. 

```
services:
  radicale:
    .... 
    environment:
        - TZ=Europe/Berlin
```