### PR TITLE
Use logging conf template from release

### DIFF
--- a/config
+++ b/config
@@ -119,9 +119,17 @@ filesystem_folder = /data/collections
 
 [logging]
 
-# Threshold for the logger
-# Value: debug | info | warning | error | critical
-#level = warning
+# Logging configuration file
+# If no config is given, simple information is printed on the standard output
+# For more information about the syntax of the configuration file, see:
+# http://docs.python.org/library/logging.config.html
+#config =
+
+# Set the default logging level to debug
+#debug = False
+
+# Store all environment variables (including those set in the shell)
+#full_environment = False
 
 # Don't include passwords in logs
 #mask_passwords = True


### PR DESCRIPTION
Hey first thanks for this amazing dockerfile - saved me a lot of work!

I only figured one problem when setting log level to `debug`: the container didn't start with exception `ERROR: Invalid configuration: Invalid option 'level' in section 'logging' in config`. I first was confused as that's what the radicale conf template suggest as well, but then I figured that since release 2.1.11 a couple of things changed in logger config. 

So IMHO the docker image conf template should align to the template of the release https://github.com/Kozea/Radicale/blob/8387a4c33f650d4392d6085750000f27ee51f278/config fix in that PR.