### PR TITLE
Integrate git cloning and pushing

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ git push --delete origin latest && git tag -d latest && git tag latest && git pu
 
 ## Contributors
 
+* [Dylan Van Assche](https://github.com/DylanVanAssche): Hook to read/write to a Git repo
 * [adzero](https://github.com/adzero): override build args with environment variables
 * [Robert Beal](https://github.com/robertbeal): fixed/configurable userId, versioning...
 * [Loader23](https://github.com/Loader23): config volume idea

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ To enable this feature, you need to provide the following environment variables:
 - `GIT_REPOSITORY`: The URL of your repository with a valid username and password or a personal access token. For example: `https://user:pass@github.com/user/repo`.
 - `GIT_USERNAME`: The username to use for commits 
 - `GIT_EMAIL`: The email to use for commits
+
 And enable the hook in the configuration file:
 
 ```

--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ docker build -t radicale-extended -f Dockerfile.extended .
 docker run --name radicale-extended -p 5232:5232 radicale-extended
 ```
 
+## Using Radicale's hook for git operations
+
+Radicale supports a hook which is executed after each change to the CalDAV/CardDAV files.
+This hook can be used to keep a versions of your CalDAV/CardDAV files through git.
+
+To enable this feature, you need to provide the following environment variables:
+- `GIT_REPOSITORY`: The URL of your repository with a valid username and password or a personal access token. For example: `https://user:pass@github.com/user/repo`.
+- `GIT_USERNAME`: The username to use for commits 
+- `GIT_EMAIL`: The email to use for commits
+And enable the hook in the configuration file:
+
+```
+[storage]
+hook = git add -A && (git diff --cached --quiet || git commit -m "Changes by "%(user)s) && git push origin master
+```
+
+*Note: If you don't enable the hook, Radicale will only read from the git repository.*
+
 ## Custom User/Group ID for the data volume
 
 You will certainly mount a volume to keep Radicale data between restart/upgrade of the container.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,6 +10,15 @@ if [ -n "$UID" ]; then
     usermod -o -u "$UID" radicale
 fi
 
+# Clone Git repository if enabled
+if [ -n "$GIT_REPOSITORY" ] && [ -n "$GIT_USERNAME" ] && [ -n "$GIT_EMAIL" ]; then
+    git clone "$GIT_REPOSITORY" /data/collections
+
+    # Git needs to know an identity for pushing changes
+    git config --system user.name "$GIT_USERNAME"
+    git config --system user.email "$GIT_EMAIL"
+fi
+
 # Re-set permission to the `radicale` user if current user is root
 # This avoids permission denied if the data volume is mounted by root
 if [ "$1" = 'radicale' ] && [ "$(id -u)" = '0' ]; then


### PR DESCRIPTION
This PR adds the setup to use git cloning and pushing of your CalDAV/CardDAV files.

You need the following environment variables:

1. `GIT_REPOSITORY`: The repository URL, with username and password, example: `https://myuser:mypass@github.com/myuser/myrepo`
2. `GIT_USERNAME`: The username to be used for commits
3. `GIT_EMAIL`: The email to be used for commits

And enable the `hook` in your config file:

```
[storage]
hook = git add -A && (git diff --cached --quiet || git commit -m "Changes by "%(user)s) && git push origin master
```

This option is fully optional, if the environment variables are not defined, the git repository is not used.
Looking forward to your review :)