### PR TITLE
Upgrade to Radicale v3.0.6

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-python 3.6.2
+python 3.8.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services: docker
 language: python
 
 python:
-  - '3.6'
+  - '3.8'
 
 addons:
   apt:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [3.0.6.0] - 2020-10-26
+
+### Changed
+
+- :sparkles: First version base on Radicale 3 ([version 3.0.6](https://github.com/Kozea/Radicale/blob/3.0.x/NEWS.md#306) exactly)
+
 ## [2.1.12.1] - 2020-06-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- :sparkles: First version base on Radicale 3 ([version 3.0.6](https://github.com/Kozea/Radicale/blob/3.0.x/NEWS.md#306) exactly)
+- :sparkles: First version based on Radicale 3 ([version 3.0.6](https://github.com/Kozea/Radicale/blob/3.0.x/NEWS.md#306) exactly)
 
 ## [2.1.12.1] - 2020-06-03
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM alpine:3.10
+FROM alpine:3.12
 
 ARG COMMIT_ID
 ENV COMMIT_ID ${COMMIT_ID}
 
 ARG VERSION
-ENV VERSION ${VERSION:-2.1.12}
+ENV VERSION ${VERSION:-3.0.6}
 
 ARG BUILD_UID
 ENV BUILD_UID ${BUILD_UID:-2999}
@@ -23,18 +23,19 @@ LABEL maintainer="Thomas Queste <tom@tomsquest.com>" \
 
 RUN apk add --no-cache --virtual=build-dependencies \
         gcc \
-        libffi-dev \
         musl-dev \
+        libffi-dev \
         python3-dev \
     && apk add --no-cache \
-        wget \
         curl \
         git \
-        python3 \
         shadow \
         su-exec \
         tzdata \
+        wget \
+        python3 \
         py3-tz \
+        py3-pip \
     && python3 -m pip install --upgrade pip \
     && python3 -m pip install radicale==$VERSION passlib[bcrypt] \
     && apk del --purge build-dependencies \

--- a/Pipfile
+++ b/Pipfile
@@ -4,10 +4,11 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
+testinfra = "*"
 
 [dev-packages]
 testinfra = "*"
 pytest = "*"
 
 [requires]
-python_version = "3.6"
+python_version = "3.8"

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,6 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-testinfra = "*"
 
 [dev-packages]
 testinfra = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c0ed5caaaa8a607bd99637bc324abd3fdd68dfe1cfc88fe4eb81db39a14ad7a2"
+            "sha256": "b10d619a306012268d70a3326b7c7cf9d806d6c840ba2a62400d7660e5216012"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.6"
+            "python_version": "3.8"
         },
         "sources": [
             {
@@ -15,69 +15,164 @@
             }
         ]
     },
-    "default": {},
-    "develop": {
-        "atomicwrites": {
-            "hashes": [
-                "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
-                "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
-            ],
-            "markers": "python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.2.*' and python_version != '3.1.*'",
-            "version": "==1.2.1"
-        },
+    "default": {
         "attrs": {
             "hashes": [
-                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
-                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+                "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594",
+                "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"
             ],
-            "version": "==18.2.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.2.0"
         },
-        "more-itertools": {
+        "iniconfig": {
             "hashes": [
-                "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092",
-                "sha256:c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e",
-                "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d"
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
             ],
-            "version": "==4.3.0"
+            "version": "==1.1.1"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
+                "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.4"
         },
         "pluggy": {
             "hashes": [
-                "sha256:447ba94990e8014ee25ec853339faf7b0fc8050cdc3289d4d71f7f410fb90095",
-                "sha256:bde19360a8ec4dfd8a20dcb811780a30998101f078fc7ded6162f0076f50508f"
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
             ],
-            "markers": "python_version != '3.0.*' and python_version != '3.3.*' and python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.2.*'",
-            "version": "==0.8.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.13.1"
         },
         "py": {
             "hashes": [
-                "sha256:bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694",
-                "sha256:e76826342cefe3c3d5f7e8ee4316b80d1dd8a300781612ddbc765c17ba25a6c6"
+                "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2",
+                "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"
             ],
-            "markers": "python_version != '3.0.*' and python_version != '3.3.*' and python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.2.*'",
-            "version": "==1.7.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.9.0"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.7"
         },
         "pytest": {
             "hashes": [
-                "sha256:f689bf2fc18c4585403348dd56f47d87780bf217c53ed9ae7a3e2d7faa45f8e9",
-                "sha256:f812ea39a0153566be53d88f8de94839db1e8a05352ed8a49525d7d7f37861e9"
+                "sha256:7a8190790c17d79a11f847fba0b004ee9a8122582ebff4729a082c109e81a4c9",
+                "sha256:8f593023c1a0f916110285b6efd7f99db07d59546e3d8c36fc60e2ab05d3be92"
             ],
-            "index": "pypi",
-            "version": "==4.0.2"
+            "markers": "python_version >= '3.5'",
+            "version": "==6.1.1"
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "markers": "python_version >= '2.6' and python_version != '3.0.*' and python_version != '3.1.*'",
-            "version": "==1.12.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.15.0"
         },
         "testinfra": {
             "hashes": [
-                "sha256:4a0a70355b007729d78446c86bffd80bcea4ffe9adc9571f9c9779476c49153d"
+                "sha256:9d3a01fb787253df76ac4ab46d18a84d4b01be877ed1b5812e590dcf480a627e",
+                "sha256:baf1d809ea2dc22c0cb5b9441bf4e17c1eb653e1ccc02cc63137d0ab467fa1de"
             ],
             "index": "pypi",
-            "version": "==1.18.0"
+            "version": "==5.3.1"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f",
+                "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"
+            ],
+            "version": "==0.10.1"
+        }
+    },
+    "develop": {
+        "attrs": {
+            "hashes": [
+                "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594",
+                "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.2.0"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+            ],
+            "version": "==1.1.1"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
+                "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.4"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.13.1"
+        },
+        "py": {
+            "hashes": [
+                "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2",
+                "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.9.0"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.7"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:7a8190790c17d79a11f847fba0b004ee9a8122582ebff4729a082c109e81a4c9",
+                "sha256:8f593023c1a0f916110285b6efd7f99db07d59546e3d8c36fc60e2ab05d3be92"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==6.1.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.15.0"
+        },
+        "testinfra": {
+            "hashes": [
+                "sha256:9d3a01fb787253df76ac4ab46d18a84d4b01be877ed1b5812e590dcf480a627e",
+                "sha256:baf1d809ea2dc22c0cb5b9441bf4e17c1eb653e1ccc02cc63137d0ab467fa1de"
+            ],
+            "index": "pypi",
+            "version": "==5.3.1"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f",
+                "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"
+            ],
+            "version": "==0.10.1"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b10d619a306012268d70a3326b7c7cf9d806d6c840ba2a62400d7660e5216012"
+            "sha256": "fdf75541c780e63947b8405fe8fcdc6b6257ca06f63f29ac830ef82364371d27"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -15,94 +15,15 @@
             }
         ]
     },
-    "default": {
-        "attrs": {
-            "hashes": [
-                "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594",
-                "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.2.0"
-        },
-        "iniconfig": {
-            "hashes": [
-                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
-                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
-            ],
-            "version": "==1.1.1"
-        },
-        "packaging": {
-            "hashes": [
-                "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
-                "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.4"
-        },
-        "pluggy": {
-            "hashes": [
-                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
-                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.13.1"
-        },
-        "py": {
-            "hashes": [
-                "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2",
-                "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.9.0"
-        },
-        "pyparsing": {
-            "hashes": [
-                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
-                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
-            ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.4.7"
-        },
-        "pytest": {
-            "hashes": [
-                "sha256:7a8190790c17d79a11f847fba0b004ee9a8122582ebff4729a082c109e81a4c9",
-                "sha256:8f593023c1a0f916110285b6efd7f99db07d59546e3d8c36fc60e2ab05d3be92"
-            ],
-            "markers": "python_version >= '3.5'",
-            "version": "==6.1.1"
-        },
-        "six": {
-            "hashes": [
-                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
-                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.15.0"
-        },
-        "testinfra": {
-            "hashes": [
-                "sha256:9d3a01fb787253df76ac4ab46d18a84d4b01be877ed1b5812e590dcf480a627e",
-                "sha256:baf1d809ea2dc22c0cb5b9441bf4e17c1eb653e1ccc02cc63137d0ab467fa1de"
-            ],
-            "index": "pypi",
-            "version": "==5.3.1"
-        },
-        "toml": {
-            "hashes": [
-                "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f",
-                "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"
-            ],
-            "version": "==0.10.1"
-        }
-    },
+    "default": {},
     "develop": {
         "attrs": {
             "hashes": [
-                "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594",
-                "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"
+                "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6",
+                "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.2.0"
+            "version": "==20.3.0"
         },
         "iniconfig": {
             "hashes": [
@@ -145,11 +66,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:7a8190790c17d79a11f847fba0b004ee9a8122582ebff4729a082c109e81a4c9",
-                "sha256:8f593023c1a0f916110285b6efd7f99db07d59546e3d8c36fc60e2ab05d3be92"
+                "sha256:4288fed0d9153d9646bfcdf0c0428197dba1ecb27a33bb6e031d002fa88653fe",
+                "sha256:c0a7e94a8cdbc5422a51ccdad8e6f1024795939cc89159a0ae7f0b316ad3823e"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==6.1.1"
+            "index": "pypi",
+            "version": "==6.1.2"
         },
         "six": {
             "hashes": [
@@ -169,10 +90,11 @@
         },
         "toml": {
             "hashes": [
-                "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f",
-                "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "version": "==0.10.1"
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.2"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Enhanced Docker image for <a href="http://radicale.org">Radicale</a>, the CalDAV
 ## Features
 
 * :closed_lock_with_key: **Secured**: run as a normal user, not root
-* :sparkles: **Enhanced**: add Git for [versioning](http://radicale.org/versioning/), Bcrypt for [authentication
-](http://radicale.org/setup/#authentication), Pytz for timezone conversion
+* :fire: **Safe**: the container is read-only, with only access to its data dir, and without extraneous privileges
+* :sparkles: **Batteries included**: can use Git for [versioning](https://radicale.org/3.0.html#tutorials/versioning-with-git) using [only environment variables](https://github.com/tomsquest/docker-radicale/#using-radicales-hook-for-git-operations), Pytz for proper timezone conversion
 * :building_construction: **Multi-architecture**: run on amd64, arm (RaspberryPI...) and others 
 
 ## Changelog
@@ -42,7 +42,21 @@ docker run -d --name radicale \
     tomsquest/docker-radicale
 ```
 
-**Production-grade** instruction (secured, safe...):
+**Basic** instruction:
+
+1. create the folders to store the data and the config: `mkdir -p /radicale/{data,config}`
+1. copy the [config file](https://raw.githubusercontent.com/tomsquest/docker-radicale/master/config) into the config folder: `cp config /radicale/config/config`
+1. Then run the container:
+
+```
+docker run -d --name radicale \
+    -p 5232:5232 \
+    tomsquest/docker-radicale \
+    -v /radicale/data:/data \
+    -v /radicale/config:/config:ro \
+```
+
+:rocket: **Production-grade** instruction (secured, safe...):
 
 ```
 docker run -d --name radicale \
@@ -183,21 +197,21 @@ Else, the image is also tagged with this scheme:
 
 Version number = Architecture + '.' + Radicale version + '.' + This image increment number
 
-Example: those tags were created for Radicale 2.1.12:
-- `tomsquest/docker-radicale:386.2.1.12.0`
-- `tomsquest/docker-radicale:amd64.2.1.12.0`
-- `tomsquest/docker-radicale:arm.2.1.12.0`
-- `tomsquest/docker-radicale:arm64.2.1.12.0`
+Example: those tags were created for Radicale 3.0.6:
+- `tomsquest/docker-radicale:386.3.0.6.0`
+- `tomsquest/docker-radicale:amd64.3.0.6.0`
+- `tomsquest/docker-radicale:arm.3.0.6.0`
+- `tomsquest/docker-radicale:arm64.3.0.6.0`
 
-The last number is ours, incremented on changes. 
+The last number is **ours**, and it is incremented on new release. 
 
 For example, 2.1.11.**2** made the /config readonly (this is specific to this image).
 
-Additionally, Docker Hub automatically build and [publish this image as `tomsquest/docker-radicale`](https://hub.docker.com/r/tomsquest/docker-radicale/).
+Additionally, Docker Hub automatically builds and [publish this image as `tomsquest/docker-radicale`](https://hub.docker.com/r/tomsquest/docker-radicale/).
 
 ## Contributing
 
-To run the tests (your user will need to be a member of the `docker` group)
+To run the tests:
 
 1. `pip install pipenv`
 1. `pipenv install -d`
@@ -205,15 +219,15 @@ To run the tests (your user will need to be a member of the `docker` group)
 
 ## Releasing
 
-1. Create a Git tag, eg. `2.1.11.0`, push it and Travis will build the images and publish them on Docker hub
+1. Create a Git tag, eg. `3.0.6.0`, push it and Travis will build the images and publish them on Docker hub
 1. Update the `latest` tag
 
 Example instructions :
 
 ```bash
 # Next release
-git tag 2.1.11.0
-git push origin 2.1.11.0
+git tag 3.0.6.0
+git push origin 3.0.6.0
 
 # latest tag
 git push --delete origin latest && git tag -d latest && git tag latest && git push origin latest

--- a/ci/build-push.sh
+++ b/ci/build-push.sh
@@ -19,9 +19,9 @@ fi
 for arch in "${archs[@]}"
 do
   case "$arch" in
-    amd64   ) base_image="balenalib/amd64-alpine:3.10" ;;
-    i386    ) base_image="balenalib/i386-alpine:3.10" ;;
-    arm     ) base_image="balenalib/armv7hf-alpine:3.10" ;;
+    amd64 ) base_image="balenalib/amd64-alpine:3.10" ;;
+    i386  ) base_image="balenalib/i386-alpine:3.10" ;;
+    arm   ) base_image="balenalib/armv7hf-alpine:3.10" ;;
     arm64 ) base_image="balenalib/aarch64-alpine:3.10" ;;
   esac
 

--- a/config
+++ b/config
@@ -40,15 +40,6 @@ hosts = 0.0.0.0:5232
 # TCP traffic between Radicale and a reverse proxy
 #certificate_authority =
 
-# SSL Protocol used. See python's ssl module for available values
-#protocol = PROTOCOL_TLSv1_2
-
-# Available ciphers. See python's ssl module for available ciphers
-#ciphers =
-
-# Reverse DNS to resolve client address in logs
-#dns_lookup = True
-
 
 [encoding]
 
@@ -69,10 +60,9 @@ hosts = 0.0.0.0:5232
 #htpasswd_filename = /etc/radicale/users
 
 # Htpasswd encryption method
-# Value: plain | sha1 | ssha | crypt | bcrypt | md5
-# Only bcrypt can be considered secure.
-# bcrypt and md5 require the passlib library to be installed.
-#htpasswd_encryption = bcrypt
+# Value: plain | bcrypt | md5
+# bcrypt requires the installation of radicale[bcrypt].
+#htpasswd_encryption = md5
 
 # Incorrect authentication delay (seconds)
 #delay = 1
@@ -112,24 +102,15 @@ filesystem_folder = /data/collections
 [web]
 
 # Web interface backend
-# Value: none | internal | radicale_infcloud
-# (See also https://github.com/Unrud/RadicaleInfCloud)
+# Value: none | internal
 #type = internal
 
 
 [logging]
 
-# Logging configuration file
-# If no config is given, simple information is printed on the standard output
-# For more information about the syntax of the configuration file, see:
-# http://docs.python.org/library/logging.config.html
-#config =
-
-# Set the default logging level to debug
-#debug = False
-
-# Store all environment variables (including those set in the shell)
-#full_environment = False
+# Threshold for the logger
+# Value: debug | info | warning | error | critical
+#level = warning
 
 # Don't include passwords in logs
 #mask_passwords = True

--- a/test_image_custom_build.py
+++ b/test_image_custom_build.py
@@ -6,7 +6,7 @@ import testinfra
 def host(request):
     subprocess.check_call(
         ['docker', 'build', '-t', 'radicale-under-test',
-         '--build-arg', 'VERSION=2.1.12',
+         '--build-arg', 'VERSION=3.0.6',
          '--build-arg', 'BUILD_UID=6666',
          '--build-arg', 'BUILD_GID=7777',
          '.'
@@ -28,7 +28,7 @@ def test_port(host):
     assert host.socket('tcp://0.0.0.0:5232').is_listening
 
 def test_version(host):
-    assert host.check_output('radicale --version') == '2.1.12'
+    assert host.check_output('radicale --version') == '3.0.6'
 
 def test_user(host):
     user = 'radicale'

--- a/test_image_prod.py
+++ b/test_image_prod.py
@@ -37,7 +37,7 @@ def test_port(host):
 
 
 def test_version(host):
-    assert host.check_output('radicale --version') == '2.1.12'
+    assert host.check_output('radicale --version') == '3.0.6'
 
 
 def test_user(host):


### PR DESCRIPTION
Upgrade to latest radicale.

Also updated:
- Alpine
- Python

Image has been pushed with name `tomsquest/docker-radicale:v3-test`, so it can be pulled with:

```
docker pull tomsquest/docker-radicale:v3-test
```
