### PR TITLE
fix starting issues

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,28 +5,28 @@ set -e
 # Change uid/gid of radicale if vars specified
 if [ -n "$UID" ] || [ -n "$GID" ]; then
     if [ ! "$UID" = "$(id radicale -u)" ] || [ ! "$GID" = "$(id radicale -g)" ]; then
-      # Fail on read-only container
-      if grep -e "\s/\s.*\sro[\s,]" /proc/mounts > /dev/null; then
-          echo "You specified custom UID/GID (UID: $UID, GID: $GID)."
-          echo "UID/GID can only be changed when not running the container with --read-only."
-          echo "Please see the README.md for how to proceed and for explanations."
-          exit 1
-      fi
+        # Fail on read-only container
+        if grep -e "\s/\s.*\sro[\s,]" /proc/mounts > /dev/null; then
+            echo "You specified custom UID/GID (UID: $UID, GID: $GID)."
+            echo "UID/GID can only be changed when not running the container with --read-only."
+            echo "Please see the README.md for how to proceed and for explanations."
+            exit 1
+        fi
 
-      if [ -n "$UID" ]; then
-          usermod -o -u "$UID" radicale
-      fi
+        if [ -n "$UID" ]; then
+            usermod -o -u "$UID" radicale
+        fi
 
-      if [ -n "$GID" ]; then
-          groupmod -o -g "$GID" radicale
-      fi
+        if [ -n "$GID" ]; then
+            groupmod -o -g "$GID" radicale
+        fi
     fi
 fi
 
 # Re-set permission to the `radicale` user if current user is root
 # This avoids permission denied if the data volume is mounted by root
 if [ "$1" = 'radicale' ] && [ "$(id -u)" = '0' ]; then
-    chown -R radicale:radicale /data
+    chown -R radicale:radicale /data || true
     exec su-exec radicale "$@"
 else
     exec "$@"

--- a/test_image_custom_build.py
+++ b/test_image_custom_build.py
@@ -41,7 +41,7 @@ def test_config_readonly(host):
     config_file = '/config/config'
     assert host.file(config_file).user == 'root'
     assert host.file(config_file).group == 'root'
-    assert host.file(config_file).mode == 0o664
+    assert host.file(config_file).mode == 0o644
 
 def test_data_folder_writable(host):
     folder = '/data'

--- a/test_image_prod.py
+++ b/test_image_prod.py
@@ -12,8 +12,7 @@ def host(request):
         '--init',
         '--read-only',
         '--security-opt=no-new-privileges:true',
-        # Not able to use cap-drop=all and make the container start
-        # '--cap-drop', 'ALL', '--cap-add', 'SYS_ADMIN', '--cap-add', 'CHOWN', '--cap-add', 'SETUID', '--cap-add', 'SETGID', '--cap-add', 'KILL',
+        '--cap-drop', 'ALL', '--cap-add', 'SYS_ADMIN', '--cap-add', 'CHOWN', '--cap-add', 'SETUID', '--cap-add', 'SETGID', '--cap-add', 'KILL',
         '--pids-limit', '50',
         '--memory', '256M',
         'radicale-under-test'
@@ -52,7 +51,7 @@ def test_config_readonly(host):
     config_file = '/config/config'
     assert host.file(config_file).user == 'root'
     assert host.file(config_file).group == 'root'
-    assert host.file(config_file).mode == 0o664
+    assert host.file(config_file).mode == 0o644
 
 
 def test_data_folder_writable(host):


### PR DESCRIPTION
Starting with the recommended privilege drops fails because of:
* root not being able to chown once /data is no longer owned by root
* git clone needs to be executed as radicale once /data is no longer root owned
* /etc/gitconfig is read-only
* git clone fails if the repo has already been cloned (existence check of the .git folder needs to be done by radicale as well since root can't even read /data, which is why I put the radicale exec stuff in a separate shell script instead of using a bunch of su-exec for every command)

I couldn't really figure out the logic of the thing (when would the entrypoint script not be executed by root for instance). So if I've done it all wrong, please let me know the logic, and I'll fix it the "proper" way.