### PR TITLE
Update IMAP plugin references for Radicale 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,15 +111,18 @@ It can be [extended](https://docs.docker.com/compose/production/#modify-your-com
 
 The image is extendable, as per Docker image architecture. You need to create your own `Dockerfile`.
 
-For example, here is how to add [radicale-imap](https://gitlab.com/comzeradd/radicale-imap) (authenticate by email) 
+For example, here is how to add [RadicaleIMAP](https://github.com/Unrud/RadicaleIMAP) (authenticate by email) 
 and [RadicaleInfCloud](https://www.inf-it.com/open-source/clients/infcloud/) (an alternative UI) to the image.
+
+Please note that the [radicale-imap](https://gitlab.com/comzeradd/radicale-imap) plugin is not compatible with
+Radicale 3.0 anymore!
 
 First, create a `Dockerfile.extended` (pick the name you want) with this content:
 
 ```dockerfile
 FROM tomsquest/docker-radicale
 
-RUN python3 -m pip install radicale-imap
+RUN python3 -m pip install git+https://github.com/Unrud/RadicaleIMAP
 RUN python3 -m pip install git+https://github.com/Unrud/RadicaleInfCloud
 ```
 


### PR DESCRIPTION
The imap plugin linked to until now (https://gitlab.com/comzeradd/radicale-imap) is not compatible with 3.0 anymore, while the original plugin from UnRud was updated: https://github.com/Unrud/RadicaleIMAP
This is quite nasty, because you don't even get a useful error message with `debug` level logging... just a 500 server error on login attempts.