### PR TITLE
Fix docker-compose volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Enhanced Docker image for <a href="http://radicale.org">Radicale</a>, the CalDAV
 ```
 docker run -d --name radicale \
     -p 5232:5232 \
-    -v ~/radicale/data:/data \
+    -v ./data:/data \
     tomsquest/docker-radicale
 ```
 
@@ -62,7 +62,7 @@ docker run -d --name radicale \
     --health-cmd="curl --fail http://localhost:5232 || exit 1" \
     --health-interval=30s \
     --health-retries=3 \
-    -v ~/radicale/data:/data \
+    -v ./data:/data \
     tomsquest/docker-radicale
 ```
 
@@ -165,7 +165,7 @@ To solve this, this image offers four options (see below for details):
 
 ### Option 0: Do nothing, permission will be fixed by the container itself
 
-When running the container with a /data volume (eg. `-v ~/radicale/data:/data`), the container entrypoint will automatically fix the permissions on `/data`. 
+When running the container with a /data volume (eg. `-v ./data:/data`), the container entrypoint will automatically fix the permissions on `/data`.
 
 This option is OK, but not optimal:
 - Ok for the container, as inside the container, the `radicale` user can read and write its data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,4 +26,4 @@ services:
       retries: 3
     restart: unless-stopped
     volumes:
-      - ~/radicale/data:/data
+      - ./data:/data


### PR DESCRIPTION
This fixes a bug when trying to start the container using docker-compose. 

```
ERROR: for radicale  Cannot start service radicale: OCI runtime create failed: container_linux.go:380: starting container process caused: process_linux.go:545: container init caused: rootfs_linux.go:76: mounting "/home/user/radicale/config" to rootfs at "/config" caused: mount through procfd: not a directory: unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type
```

Also, I changed the path on the host to be relative to the docker-compose file so it no longer assumes the full path of the project.