### PR TITLE
feat: only support amd64 and arm64 architectures (drop i386 and arm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Enhanced Docker image for <a href="http://radicale.org">Radicale</a>, the CalDAV
 ## Features
 
 * :closed_lock_with_key: **Secured**: the container is read-only, with only access to its data dir, and without extraneous privileges
-* :building_construction: **Multi-architecture**: run on amd64, arm (RaspberryPI...) and others
+* :building_construction: **Multi-architecture**: run on amd64 and arm64 (RaspberryPI...)
 * :fire: **Safe**: run as a normal user (not root)
 * :sparkles: **Batteries included**: git included for [versioning](https://github.com/tomsquest/docker-radicale/#versioning-with-git) and Pytz/tz-data for proper timezone handling
 
@@ -112,7 +112,7 @@ It can also be [extended](https://docs.docker.com/compose/production/#modify-you
 
 ## Multi-architecture
 
-The correct image type for your architecture will be automatically selected by Docker.
+The correct image type for your architecture will be automatically selected by Docker, whether it is amd64 or arm64 (RaspberryPI).
 
 ## Extending the image
 

--- a/ci/build-push.sh
+++ b/ci/build-push.sh
@@ -8,6 +8,8 @@ echo "$DOCKER_PWD" | docker login -u "$DOCKER_USER" --password-stdin
 # Require to build docker image of other architectures
 docker run --rm --privileged multiarch/qemu-user-static:register --reset
 
+archs=(amd64 386 arm arm64)
+
 if [ -z "$TRAVIS_TAG" ]
 then
   DOCKERFILE_SUFFIX=""
@@ -17,14 +19,12 @@ else
   DOCKER_TAG="$TRAVIS_TAG"
 fi
 
-archs=(amd64 386 arm arm64)
+archs=(amd64 arm64)
 
 for arch in "${archs[@]}"
 do
   case "$arch" in
     amd64 ) base_image="alpine:3.14" ;;
-    386   ) base_image="balenalib/i386-alpine:3.14" ;;
-    arm   ) base_image="balenalib/armv7hf-alpine:3.14" ;;
     arm64 ) base_image="balenalib/aarch64-alpine:3.14" ;;
   esac
 
@@ -43,16 +43,10 @@ export DOCKER_CLI_EXPERIMENTAL=enabled
 
 docker manifest create tomsquest/docker-radicale:$DOCKER_TAG \
   tomsquest/docker-radicale:amd64$DOCKERFILE_SUFFIX \
-  tomsquest/docker-radicale:386$DOCKERFILE_SUFFIX \
-  tomsquest/docker-radicale:arm$DOCKERFILE_SUFFIX \
   tomsquest/docker-radicale:arm64$DOCKERFILE_SUFFIX
 
 docker manifest annotate tomsquest/docker-radicale:$DOCKER_TAG \
   tomsquest/docker-radicale:amd64$DOCKERFILE_SUFFIX --arch amd64
-docker manifest annotate tomsquest/docker-radicale:$DOCKER_TAG \
-  tomsquest/docker-radicale:386$DOCKERFILE_SUFFIX --arch 386
-docker manifest annotate tomsquest/docker-radicale:$DOCKER_TAG \
-  tomsquest/docker-radicale:arm$DOCKERFILE_SUFFIX --arch arm
 docker manifest annotate tomsquest/docker-radicale:$DOCKER_TAG \
   tomsquest/docker-radicale:arm64$DOCKERFILE_SUFFIX --arch arm64
 


### PR DESCRIPTION
- `i386` arch was not working due to a bug in the build script (was amd64), so I assume nobody was using it
- `arm` (not `arm64`) has problem building with balenalib images for some weird errors. So unless someone complains or I found a working base image, support is removed.