### PR TITLE
fix: support for running image as non-root without requiring dropping privileges using su-exec.

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,7 +29,7 @@ if [ "$(id -u)" = "0" ] && [ "$TAKE_FILE_OWNERSHIP" = "true" ]; then
 fi
 
 # Run radicale as the "radicale" user or any other command if provided
-if [ "$1" = "radicale" ]; then
+if [ "$(id -u)" = "0" ] && [ "$1" = "radicale" ]; then
     exec su-exec radicale "$@"
 else
     exec "$@"


### PR DESCRIPTION
Using docker-radicale image in a hardened environment (for instance using "user: 2999" in docker-compose.yml) does not work since su-exec is always executed despite what user the container is running as (except root). su-exec always requires root anyway, so today docker-entrypoint.sh breaks the possibility to set container user before executing inside the container.

This pull request makes the image support setting user at build-time so container does not have to be started as root and then drop privileges using su-exec. For demo, Ihave created a container from my fork where the forked container is extended with files owned by the user id and group id matching the user field value in docker-compose.yml.

Example:
```
FROM hecd/docker-radicale:latest

COPY --chown=2999:2999 config/radicale/config /config/config
COPY --chown=2999:2999 config/radicale/users  /config/users
RUN chown 2999:2999 /usr/local/bin/docker-entrypoint.sh
```

Avoiding su-exec also means following capabilities are no longer required and can therefore be dropped using cap_drop:
- SETUID
- SETGID