### PR TITLE
fix: add openssh for git ssh remotes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN apk add --no-cache --virtual=build-dependencies \
     && apk add --no-cache \
         curl \
         git \
+        openssh \
         shadow \
         su-exec \
         tzdata \


### PR DESCRIPTION
Docker container currently doesn't contain an ssh binary and as thus when using a hook for git, ssh remotes cannot be used.  
This change should fix that