### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.17.2
 
 ARG COMMIT_ID
 ENV COMMIT_ID ${COMMIT_ID}


### PR DESCRIPTION
Update alpine to 3.17.2. alpine 3.14 has 5 critical vuins.

tomsquest/docker-radicale (alpine 3.14.6)

Total: 26 (MEDIUM: 9, HIGH: 12, CRITICAL: 5)

┌──────────────┬────────────────┬──────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│   Library    │ Vulnerability  │ Severity │ Installed Version │ Fixed Version │                            Title                            │
├──────────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ curl         │ CVE-2022-43551 │ HIGH     │ 7.79.1-r2         │ 7.79.1-r4     │ curl: HSTS bypass via IDN                                   │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-43551                  │
│              ├────────────────┤          │                   │               ├─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-43552 │          │                   │               │ curl: Use-after-free triggered by an HTTP proxy deny        │
│              │                │          │                   │               │ response                                                    │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-43552                  │
│              ├────────────────┼──────────┤                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-23916 │ MEDIUM   │                   │ 7.79.1-r5     │ [curl: HTTP multi-header compression denial of service]     │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-23916                  │
├──────────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ expat        │ CVE-2022-40674 │ HIGH     │ 2.4.7-r0          │ 2.4.9-r0      │ expat: a use-after-free in the doContent function in        │
│              │                │          │                   │               │ xmlparse.c                                                  │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-40674                  │
│              ├────────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-43680 │          │                   │ 2.5.0-r0      │ expat: use-after free caused by overeager destruction of a  │
│              │                │          │                   │               │ shared DTD in...                                            │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-43680                  │
├──────────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ git          │ CVE-2022-23521 │ CRITICAL │ 2.32.3-r0         │ 2.32.5-r0     │ Git is distributed revision control system. gitattributes   │
│              │                │          │                   │               │ are a mechan ...                                            │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-23521                  │
│              ├────────────────┤          │                   │               ├─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-41903 │          │                   │               │ Git is distributed revision control system. `git log` can   │
│              │                │          │                   │               │ display comm ......                                         │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-41903                  │
│              ├────────────────┼──────────┤                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-39260 │ HIGH     │                   │ 2.32.4-r0     │ git: git shell function that splits command arguments can   │
│              │                │          │                   │               │ lead to arbitrary...                                        │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-39260                  │
│              ├────────────────┼──────────┤                   │               ├─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-39253 │ MEDIUM   │                   │               │ git: exposure of sensitive information to a malicious actor │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-39253                  │
│              ├────────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-22490 │          │                   │ 2.32.6-r0     │ Git is a revision control system. Using a specially-crafted │
│              │                │          │                   │               │ repository ...                                              │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-22490                  │
│              ├────────────────┤          │                   │               ├─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-23946 │          │                   │               │ Git, a revision control system, is vulnerable to path       │
│              │                │          │                   │               │ traversal prior ...                                         │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-23946                  │
├──────────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libcrypto1.1 │ CVE-2023-0286  │ CRITICAL │ 1.1.1n-r0         │ 1.1.1t-r0     │ There is a type confusion vulnerability relating to X.400   │
│              │                │          │                   │               │ address proc ......                                         │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0286                   │
│              ├────────────────┼──────────┤                   │               ├─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-4450  │ HIGH     │                   │               │ The function PEM_read_bio_ex() reads a PEM file from a BIO  │
│              │                │          │                   │               │ and parses...                                               │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4450                   │
│              ├────────────────┤          │                   │               ├─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0215  │          │                   │               │ The public API function BIO_new_NDEF is a helper function   │
│              │                │          │                   │               │ used for str...                                             │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0215                   │
│              ├────────────────┼──────────┤                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-2097  │ MEDIUM   │                   │ 1.1.1q-r0     │ openssl: AES OCB fails to encrypt some bytes                │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-2097                   │
│              ├────────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-4304  │          │                   │ 1.1.1t-r0     │ A timing based side channel exists in the OpenSSL RSA       │
│              │                │          │                   │               │ Decryption imple...                                         │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4304                   │
├──────────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libcurl      │ CVE-2022-43551 │ HIGH     │ 7.79.1-r2         │ 7.79.1-r4     │ curl: HSTS bypass via IDN                                   │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-43551                  │
│              ├────────────────┤          │                   │               ├─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-43552 │          │                   │               │ curl: Use-after-free triggered by an HTTP proxy deny        │
│              │                │          │                   │               │ response                                                    │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-43552                  │
│              ├────────────────┼──────────┤                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-23916 │ MEDIUM   │                   │ 7.79.1-r5     │ [curl: HTTP multi-header compression denial of service]     │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-23916                  │
├──────────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libssl1.1    │ CVE-2023-0286  │ CRITICAL │ 1.1.1n-r0         │ 1.1.1t-r0     │ There is a type confusion vulnerability relating to X.400   │
│              │                │          │                   │               │ address proc ......                                         │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0286                   │
│              ├────────────────┼──────────┤                   │               ├─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-4450  │ HIGH     │                   │               │ The function PEM_read_bio_ex() reads a PEM file from a BIO  │
│              │                │          │                   │               │ and parses...                                               │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4450                   │
│              ├────────────────┤          │                   │               ├─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0215  │          │                   │               │ The public API function BIO_new_NDEF is a helper function   │
│              │                │          │                   │               │ used for str...                                             │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0215                   │
│              ├────────────────┼──────────┤                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-2097  │ MEDIUM   │                   │ 1.1.1q-r0     │ openssl: AES OCB fails to encrypt some bytes                │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-2097                   │
│              ├────────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-4304  │          │                   │ 1.1.1t-r0     │ A timing based side channel exists in the OpenSSL RSA       │
│              │                │          │                   │               │ Decryption imple...                                         │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4304                   │
├──────────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ python3      │ CVE-2022-45061 │ HIGH     │ 3.9.5-r2          │ 3.9.16-r0     │ Python: CPU denial of service via inefficient IDNA decoder  │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-45061                  │
├──────────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ zlib         │ CVE-2022-37434 │ CRITICAL │ 1.2.12-r0         │ 1.2.12-r2     │ zlib: heap-based buffer over-read and overflow in inflate() │
│              │                │          │                   │               │ in inflate.c via a...                                       │
│              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-37434                  │
└──────────────┴────────────────┴──────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────────┘
