### PR TITLE
fix: drop support for arm v7

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,8 @@
 name: build
 on: [push, pull_request,workflow_dispatch]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install pipenv
         run: pipx install pipenv
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.8'
           cache: 'pipenv'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,14 +4,29 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install pipenv
-      run: pipx install pipenv
-    - uses: actions/setup-python@v2
-      with:
-        python-version: '3.8'
-        cache: 'pipenv'
-    - name: Install dependencies
-      run: pipenv sync --dev
-    - name: Test
-      run: pipenv run pytest -v
+      - uses: actions/checkout@v3
+      - name: Install pipenv
+        run: pipx install pipenv
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+          cache: 'pipenv'
+      - name: Install dependencies
+        run: pipenv sync --dev
+      - name: Test
+        run: pipenv run pytest -v
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,6 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: tomsquest/docker-radicale:${{github.ref_name}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,9 @@ on:
   push:
     tags:
       - '*'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Enhanced Docker image for <a href="http://radicale.org">Radicale</a>, the CalDAV
 
 * :closed_lock_with_key: **Secured**: the container is read-only, with only access to its data dir, and without extraneous privileges
 * :fire: **Safe**: run as a normal user (not root)
-* :building_construction: **Multi-architecture**: run on amd64, arm64 and armv7 (Raspberry Pi, ...)
+* :building_construction: **Multi-architecture**: run on amd64 and arm64
 * :sparkles: **Batteries included**: git and ssh included for [versioning](https://github.com/tomsquest/docker-radicale/#versioning-with-git) and Pytz/tz-data for proper timezone handling
 
 ## Changelog
@@ -144,7 +144,7 @@ It can also be [extended](https://docs.docker.com/compose/production/#modify-you
 
 ## Multi-architecture
 
-The correct image type for your architecture will be automatically selected by Docker, whether it is amd64, arm64 or armv7 (Raspberry Pi).
+The correct image type for your architecture will be automatically selected by Docker, whether it is amd64 or arm64.
 
 ## Extending the image
 


### PR DESCRIPTION
Updating Alpine to 3.17 blocked the release of the arm v7.
bcrypt need rusts which cause oom or network error downloading cargo indices.
There seems to be workaround when running in tmpfs or other strange stuff.
In all case, too complex to maintain, so I am dropping support for arm v7 (which is 32bits, so a bit old).