### PR TITLE
chore: bump Alpine Version to 3.18.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.18.2
 
 ARG COMMIT_ID
 ENV COMMIT_ID ${COMMIT_ID}


### PR DESCRIPTION
Bump alpine to latest version to address vulnerabilities present in the existing alpine base image version.  


```
tomsquest/docker-radicale:3.1.8.2 (alpine 3.17.3)
=================================================
Total: 24 (UNKNOWN: 0, LOW: 3, MEDIUM: 6, HIGH: 8, CRITICAL: 7)

┌────────────────────────┬────────────────┬──────────┬───────────────────┬──────────────────┬─────────────────────────────────────────────────────────────┐
│        Library         │ Vulnerability  │ Severity │ Installed Version │  Fixed Version   │                            Title                            │
├────────────────────────┼────────────────┼──────────┼───────────────────┼──────────────────┼─────────────────────────────────────────────────────────────┤
│ curl                   │ CVE-2023-28319 │ HIGH     │ 8.0.1-r0          │ 8.1.0-r0         │ use after free in SSH sha256 fingerprint check              │
│                        │                │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-28319                  │
│                        ├────────────────┼──────────┤                   │                  ├─────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-28320 │ MEDIUM   │                   │                  │ siglongjmp race condition may lead to crash                 │
│                        │                │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-28320                  │
│                        ├────────────────┤          │                   │                  ├─────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-28321 │          │                   │                  │ IDN wildcard match may lead to Improper Cerificate          │
│                        │                │          │                   │                  │ Validation                                                  │
│                        │                │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-28321                  │
│                        ├────────────────┼──────────┤                   │                  ├─────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-28322 │ LOW      │                   │                  │ more POST-after-PUT confusion                               │
│                        │                │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-28322                  │
├────────────────────────┼────────────────┼──────────┼───────────────────┼──────────────────┼─────────────────────────────────────────────────────────────┤
│ git                    │ CVE-2023-25652 │ HIGH     │ 2.38.4-r1         │ 2.38.5-r0        │ by feeding specially crafted input to `git apply --reject`, │
│                        │                │          │                   │                  │ a path outside...                                           │
│                        │                │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-25652                  │
│                        ├────────────────┤          │                   │                  ├─────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-29007 │          │                   │                  │ arbitrary configuration injection when renaming or deleting │
│                        │                │          │                   │                  │ a section from a configuration...                           │
│                        │                │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-29007                  │
│                        ├────────────────┼──────────┤                   │                  ├─────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-25815 │ LOW      │                   │                  │ malicious placement of crafted messages when git was        │
│                        │                │          │                   │                  │ compiled with runtime prefix...                             │
│                        │                │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-25815                  │
├────────────────────────┼────────────────┼──────────┼───────────────────┼──────────────────┼─────────────────────────────────────────────────────────────┤
│ libcrypto3             │ CVE-2023-2650  │ HIGH     │ 3.0.8-r3          │ 3.0.9-r0         │ Possible DoS translating ASN.1 object identifiers           │
│                        │                │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-2650                   │
│                        ├────────────────┼──────────┤                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-1255  │ MEDIUM   │                   │ 3.0.8-r4         │ Input buffer over-read in AES-XTS implementation on 64 bit  │
│                        │                │          │                   │                  │ ARM                                                         │
│                        │                │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-1255                   │
├────────────────────────┼────────────────┼──────────┼───────────────────┼──────────────────┼─────────────────────────────────────────────────────────────┤
│ libcurl                │ CVE-2023-28319 │ HIGH     │ 8.0.1-r0          │ 8.1.0-r0         │ use after free in SSH sha256 fingerprint check              │
│                        │                │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-28319                  │
│                        ├────────────────┼──────────┤                   │                  ├─────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-28320 │ MEDIUM   │                   │                  │ siglongjmp race condition may lead to crash                 │
│                        │                │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-28320                  │
│                        ├────────────────┤          │                   │                  ├─────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-28321 │          │                   │                  │ IDN wildcard match may lead to Improper Cerificate          │
│                        │                │          │                   │                  │ Validation                                                  │
│                        │                │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-28321                  │
│                        ├────────────────┼──────────┤                   │                  ├─────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-28322 │ LOW      │                   │                  │ more POST-after-PUT confusion                               │
│                        │                │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-28322                  │
├────────────────────────┼────────────────┼──────────┼───────────────────┼──────────────────┼─────────────────────────────────────────────────────────────┤
│ libssl3                │ CVE-2023-2650  │ HIGH     │ 3.0.8-r3          │ 3.0.9-r0         │ Possible DoS translating ASN.1 object identifiers           │
│                        │                │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-2650                   │
│                        ├────────────────┼──────────┤                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-1255  │ MEDIUM   │                   │ 3.0.8-r4         │ Input buffer over-read in AES-XTS implementation on 64 bit  │
│                        │                │          │                   │                  │ ARM                                                         │
│                        │                │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-1255                   │
├────────────────────────┼────────────────┼──────────┼───────────────────┼──────────────────┼─────────────────────────────────────────────────────────────┤
│ ncurses-libs           │ CVE-2023-29491 │ HIGH     │ 6.3_p20221119-r0  │ 6.3_p20221119-r1 │ Local users can trigger security-relevant memory corruption │
│                        │                │          │                   │                  │ via malformed data                                          │
│                        │                │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-29491                  │
├────────────────────────┤                │          │                   │                  │                                                             │
│ ncurses-terminfo-base  │                │          │                   │                  │                                                             │
│                        │                │          │                   │                  │                                                             │
│                        │                │          │                   │                  │                                                             │
├────────────────────────┼────────────────┼──────────┼───────────────────┼──────────────────┼─────────────────────────────────────────────────────────────┤
│ openssh                │ CVE-2023-28531 │ CRITICAL │ 9.1_p1-r2         │ 9.1_p1-r3        │ openssh: smartcard keys to ssh-agent without the intended   │
│                        │                │          │                   │                  │ per-hop destination constraints.                            │
│                        │                │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-28531                  │
├────────────────────────┤                │          │                   │                  │                                                             │
│ openssh-client-common  │                │          │                   │                  │                                                             │
│                        │                │          │                   │                  │                                                             │
│                        │                │          │                   │                  │                                                             │
├────────────────────────┤                │          │                   │                  │                                                             │
│ openssh-client-default │                │          │                   │                  │                                                             │
│                        │                │          │                   │                  │                                                             │
│                        │                │          │                   │                  │                                                             │
├────────────────────────┤                │          │                   │                  │                                                             │
│ openssh-keygen         │                │          │                   │                  │                                                             │
│                        │                │          │                   │                  │                                                             │
│                        │                │          │                   │                  │                                                             │
├────────────────────────┤                │          │                   │                  │                                                             │
│ openssh-server         │                │          │                   │                  │                                                             │
│                        │                │          │                   │                  │                                                             │
│                        │                │          │                   │                  │                                                             │
├────────────────────────┤                │          │                   │                  │                                                             │
│ openssh-server-common  │                │          │                   │                  │                                                             │
│                        │                │          │                   │                  │                                                             │
│                        │                │          │                   │                  │                                                             │
├────────────────────────┤                │          │                   │                  │                                                             │
│ openssh-sftp-server    │                │          │                   │                  │                                                             │
│                        │                │          │                   │                  │                                                             │
│                        │                │          │                   │                  │                                                             │
└────────────────────────┴────────────────┴──────────┴───────────────────┴──────────────────┴─────────────────────────────────────────────────────────────┘
```

