### PR TITLE
doc: update image extension instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ First, create a `Dockerfile.extended` (pick the name you want) with this content
 ```dockerfile
 FROM tomsquest/docker-radicale
 
-RUN python3 -m pip install git+https://github.com/Unrud/RadicaleIMAP
-RUN python3 -m pip install git+https://github.com/Unrud/RadicaleInfCloud
+RUN /venv/bin/pip install git+https://github.com/Unrud/RadicaleIMAP
+RUN /venv/bin/pip install git+https://github.com/Unrud/RadicaleInfCloud
 ```
 
 Then, build and run it:


### PR DESCRIPTION
Since https://github.com/tomsquest/docker-radicale/pull/141, the docker image uses a `venv` for python.

Extending the docker images now requires using the venv's pip. This PR updates the README to reflect this change.