### PR TITLE
fix: auth is set to deny all by default, setting it to `none`

### DIFF
--- a/config
+++ b/config
@@ -65,6 +65,7 @@ hosts = 0.0.0.0:5232
 # Authentication method
 # Value: none | htpasswd | remote_user | http_x_remote_user | dovecot | ldap | oauth2 | pam | denyall
 #type = denyall
+type = none
 
 # Cache logins for until expiration time
 #cache_logins = false


### PR DESCRIPTION
Fix #182 

Radicale 3.5.0 defaults to `denyall` as the auth type, meaning no access to Radicale until a proper auth type is setup.
This PR set the auth type to `none` as it was in previous released.
