### PR TITLE
Dockerfile: Dependencies for radicale-birthday added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ RUN apk add --no-cache --virtual=build-dependencies \
         tzdata \
         wget \
         python3 \
+        py3-dateutil \
+        py3-vobject \
         py3-pip \
     && python -m venv /venv \
     && /venv/bin/pip install --no-cache-dir radicale==$VERSION passlib[bcrypt] pytz ldap3 \


### PR DESCRIPTION
radicale-birthday is an extension script and configuration to radicale that automatically creates a birthday-calender. It requires py3-dateutil and py3-vobject to run. The script itself can be placed in the data volume.

The script can be found here: https://github.com/iBigQ/radicale-birthday-calendar The feature is very handy and gives a nice touch to radicale itself.

Would you be willing to add those dependencies to the dockerfile?