### PR TITLE
Fix ownership of /config too

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -26,6 +26,7 @@ fi
 # If requested and running as root, mutate the ownership of bind-mounts
 if [ "$(id -u)" = "0" ] && [ "$TAKE_FILE_OWNERSHIP" = "true" ]; then
     chown -R radicale:radicale /data
+    chown -R radicale:radicale /config
 fi
 
 # Run radicale as the "radicale" user or any other command if provided


### PR DESCRIPTION
When bind-mounting /config into the container, it is mounted with root as the owner -> permission error on startup.

Might be only relevant for rootless setups