### PR TITLE
Create config from environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,6 @@ HEALTHCHECK --interval=30s --retries=3 CMD curl --fail http://localhost:5232 || 
 VOLUME /config /data
 EXPOSE 5232
 
-COPY docker-entrypoint.sh /usr/local/bin
+COPY docker-entrypoint.sh create-config-from-env.py /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["/venv/bin/radicale", "--config", "/config/config"]

--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ A [Docker compose file](docker-compose.yml) is included.
 
 ## Custom configuration
 
+There are two ways to configure Radicale: using a configuration file or using environment variables.
+
+### Option 1: Configuration file
+
 To change Radicale configuration, first get the config file:
 
 * (Recommended) use this preconfigured [config file](config) from this repository,
@@ -155,6 +159,36 @@ Then:
 2. copy your config file into the config folder (e.g. `cp config /my_custom_config_directory/config`)
 3. mount your custom config volume when running the container: `-v /my_custom_config_directory:/config:ro`.
 The `:ro` at the end make the volume read-only, and is more secured.
+
+### Option 2: Environment variables
+
+You can configure Radicale using environment variables without needing to create or mount a configuration file.
+Environment variables follow the pattern: `RADICALE_CONFIG_<SECTION>_<KEY>=value`
+
+For example, to set the logging level and storage type:
+
+```bash
+docker run -d --name radicale \
+    -p 5232:5232 \
+    -e "RADICALE_CONFIG_LOGGING_LEVEL=info" \
+    -e "RADICALE_CONFIG_STORAGE_TYPE=multifilesystem" \
+    -v ./data:/data \
+    tomsquest/docker-radicale
+```
+
+The environment variable names are case-insensitive and underscores in the key name represent spaces or underscores in the actual config parameter.
+For example:
+- `RADICALE_CONFIG_SERVER_HOSTS=0.0.0.0:5232` sets `hosts` in the `[server]` section
+- `RADICALE_CONFIG_AUTH_TYPE=htpasswd` sets `type` in the `[auth]` section
+- `RADICALE_CONFIG_STORAGE_FILESYSTEM_FOLDER=/data/collections` sets `filesystem_folder` in the `[storage]` section
+
+**How it works:**
+- If you provide any `RADICALE_CONFIG_*` environment variables, the container will automatically create or update the configuration file at startup
+- Existing configuration files will be updated (not overwritten), so you can combine both methods
+- If a configuration file already exists, environment variables will override the values in the file
+- If no `RADICALE_CONFIG_*` variables are provided, the container will use the existing config file as-is
+
+**Advanced:** You can change the config file location using the `RADICALE_CONFIG_FILE` environment variable (default: `/config/config`).
 
 ## Authentication configuration
 

--- a/create-config-from-env.py
+++ b/create-config-from-env.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+
+import os
+import re
+import sys
+from pathlib import Path
+from collections import defaultdict
+
+CONFIG_FILE = os.environ.get('RADICALE_CONFIG_FILE', '/config/config')
+
+# Check if any RADICALE_CONFIG_ environment variables are set
+has_config_vars = any(key.startswith('RADICALE_CONFIG_') for key in os.environ)
+
+# If no config variables are provided, exit without touching the config
+if not has_config_vars:
+    sys.exit(0)
+
+print("Applying configuration from environment variables...")
+
+# Create config directory if it doesn't exist
+config_path = Path(CONFIG_FILE)
+config_path.parent.mkdir(parents=True, exist_ok=True)
+
+# If config file doesn't exist, create an empty one
+if not config_path.exists():
+    config_path.touch()
+
+# Read the existing config file
+with open(CONFIG_FILE, 'r') as f:
+    lines = f.readlines()
+
+# Parse environment variables
+env_configs = {}
+for key, value in os.environ.items():
+    if key.startswith('RADICALE_CONFIG_'):
+        config_path_str = key[16:]  # Remove RADICALE_CONFIG_ prefix
+        parts = config_path_str.lower().split('_', 1)
+        if len(parts) == 2:
+            section = parts[0]
+            param = parts[1].replace('_', ' ').replace(' ', '_')
+            if section not in env_configs:
+                env_configs[section] = {}
+            env_configs[section][param] = value
+            print(f"Setting [{section}] {param} = {value}")
+
+# Process the config file
+output_lines = []
+current_section = None
+section_keys_updated = defaultdict(set)
+
+i = 0
+while i < len(lines):
+    line = lines[i]
+    stripped = line.strip()
+
+    # Check if this is a section header
+    section_match = re.match(r'^\[(\w+)\]', stripped)
+    if section_match:
+        current_section = section_match.group(1)
+        output_lines.append(line)
+
+        # If we have config for this section, check if keys exist in the section
+        # We only add keys here that don't exist; existing keys will be replaced when encountered
+        if current_section in env_configs:
+            for key, value in env_configs[current_section].items():
+                if key not in section_keys_updated[current_section]:
+                    # Look ahead to see if this key exists in the section (uncommented or commented)
+                    # Check if there's an uncommented version first
+                    key_found_uncommented = False
+                    key_found_commented = False
+                    j = i + 1
+                    while j < len(lines):
+                        next_line = lines[j].strip()
+                        # Stop if we hit another section
+                        if re.match(r'^\[\w+\]', next_line):
+                            break
+                        # Check if this line contains our key
+                        # First check for uncommented version
+                        uncommented_pattern = re.compile(r'^' + re.escape(key) + r'\s*=')
+                        if uncommented_pattern.match(next_line):
+                            key_found_uncommented = True
+                            break
+                        # Then check for commented version
+                        commented_pattern = re.compile(r'^#' + re.escape(key) + r'\s*=')
+                        if commented_pattern.match(next_line) and not key_found_commented:
+                            key_found_commented = True
+                        j += 1
+
+                    # If key found (either way), it will be replaced when encountered
+                    # If not found at all, add it now
+                    if not key_found_uncommented and not key_found_commented:
+                        output_lines.append(f"{key} = {value}\n")
+                        section_keys_updated[current_section].add(key)
+
+        i += 1
+        continue
+
+    # Check if this line is a key=value pair in our target section
+    if current_section and current_section in env_configs:
+        # First check if it's an uncommented key = value
+        uncommented_match = re.match(r'^(\w+)\s*=', stripped)
+        if uncommented_match:
+            key = uncommented_match.group(1)
+            if key in env_configs[current_section] and key not in section_keys_updated[current_section]:
+                # Replace this uncommented line with the new value
+                output_lines.append(f"{key} = {env_configs[current_section][key]}\n")
+                section_keys_updated[current_section].add(key)
+                i += 1
+                continue
+
+        # Then check if it's a commented key = value
+        commented_match = re.match(r'^#(\w+)\s*=', stripped)
+        if commented_match:
+            key = commented_match.group(1)
+            if key in env_configs[current_section] and key not in section_keys_updated[current_section]:
+                # Only replace commented line if no uncommented version exists
+                # Check if there's an uncommented version later in the section
+                has_uncommented = False
+                j = i + 1
+                while j < len(lines):
+                    next_line = lines[j].strip()
+                    if re.match(r'^\[\w+\]', next_line):
+                        break
+                    if re.match(r'^' + re.escape(key) + r'\s*=', next_line):
+                        has_uncommented = True
+                        break
+                    j += 1
+
+                if not has_uncommented:
+                    # No uncommented version exists, so replace this commented one
+                    output_lines.append(f"{key} = {env_configs[current_section][key]}\n")
+                    section_keys_updated[current_section].add(key)
+                    i += 1
+                    continue
+
+    output_lines.append(line)
+    i += 1
+
+# Add any sections that didn't exist
+for section, keys in env_configs.items():
+    if section not in section_keys_updated or not section_keys_updated[section]:
+        # Check if section exists at all
+        section_exists = any(re.match(r'^\[' + section + r'\]', line.strip()) for line in output_lines)
+        if not section_exists:
+            output_lines.append(f"\n[{section}]\n")
+            for key, value in keys.items():
+                output_lines.append(f"{key} = {value}\n")
+
+# Write the updated config
+with open(CONFIG_FILE, 'w') as f:
+    f.writelines(output_lines)
+
+print(f"Configuration updated at {CONFIG_FILE}")

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Create config from environment variables if provided
+create-config-from-env.py
+
 # Change uid/gid of radicale if vars specified
 if [ -n "$UID" ] || [ -n "$GID" ]; then
     if [ ! "$UID" = "$(id radicale -u)" ] || [ ! "$GID" = "$(id radicale -g)" ]; then


### PR DESCRIPTION
Adds support for configuring Radicale using environment variables as an alternative to mounting configuration files.

## Changes
* Added `create-config-from-env.py` script to parse `RADICALE_CONFIG_*` environment variables
* Updated `docker-entrypoint.sh` to run the script at container startup
* Updated `README.md` with usage documentation

## Usage
Configure Radicale using environment variables:
```
docker run -d --name radicale \
    -p 5232:5232 \
    -e "RADICALE_CONFIG_LOGGING_LEVEL=info" \
    -e "RADICALE_CONFIG_AUTH_TYPE=htpasswd" \
    -v ./data:/data \
    tomsquest/docker-radicale
```
Pattern: `RADICALE_CONFIG_<SECTION>_<KEY>=value`

## Benefits
* Easier deployment without config file management
* Better integration with orchestration tools (Docker Compose, Kubernetes)
* Can be combined with traditional config files (env vars override file values)
* Backward compatible (only activates when `RADICALE_CONFIG_*` variables are present)